### PR TITLE
Fix after changes in svg-tree

### DIFF
--- a/Graphics/Diagrams/Backend/SVGTree.hs
+++ b/Graphics/Diagrams/Backend/SVGTree.hs
@@ -37,6 +37,7 @@ arrowHead = Marker {
   _markerUnits = Nothing,
   _markerViewBox = Nothing,
   _markerOverflow = Just OverflowVisible,
+  _markerAspectRatio = defaultSvg,
   _markerElements =
     [PathTree $ S.Path
      mempty {_transform = Just [Scale 0.8 Nothing, Rotate 180 Nothing, Translate 12.5 0]

--- a/Graphics/Diagrams/SVG.hs
+++ b/Graphics/Diagrams/SVG.hs
@@ -6,6 +6,7 @@ import System.Environment
 import Graphics.Text.TrueType
 import Options.Applicative
 import Graphics.Diagrams.Backend.SVGTree
+import Data.Monoid
 
 data Options = Options
                {


### PR DESCRIPTION
The package was no longer compatible with the latest version of `svg-tree` (`svg-tree-0.6`), preventing it from being on Stackage. These two minor fixes make it compile again.